### PR TITLE
make using ioutil.ReadAll an option in taxi use case

### DIFF
--- a/cmd/taxi.go
+++ b/cmd/taxi.go
@@ -31,6 +31,7 @@ func NewTaxiCommand(stdin io.Reader, stdout, stderr io.Writer) *cobra.Command {
 	flags.IntVarP(&TaxiMain.Concurrency, "concurrency", "c", 8, "Number of goroutines fetching and parsing")
 	flags.IntVarP(&TaxiMain.FetchConcurrency, "fetch-concurrency", "e", 8, "Number of goroutines fetching and parsing")
 	flags.IntVarP(&TaxiMain.BufferSize, "buffer-size", "b", 1000000, "Size of buffer for importers - heavily affects memory usage")
+	flags.BoolVarP(&TaxiMain.UseReadAll, "use-read-all", "", false, "Setting to true uses much more memory, but ensures that an entire file can be read before beginning to parse it.")
 	flags.StringVarP(&TaxiMain.PilosaHost, "pilosa", "p", "localhost:10101", "Pilosa host")
 	flags.StringVarP(&TaxiMain.Index, "index", "i", "taxi", "Pilosa db to write to")
 	flags.StringVarP(&TaxiMain.URLFile, "url-file", "f", "usecase/taxi/urls-short.txt", "File to get raw data urls from. Urls may be http or local files.")

--- a/usecase/taxi/main.go
+++ b/usecase/taxi/main.go
@@ -83,6 +83,7 @@ type Main struct {
 	Concurrency      int
 	Index            string
 	BufferSize       int
+	UseReadAll       bool
 
 	importer  pdk.PilosaImporter
 	urls      []string
@@ -293,26 +294,31 @@ func (m *Main) fetch(urls <-chan string, records chan<- Record) {
 			}
 			content = f
 		}
-		// we're using ReadAll here to ensure that we can read the entire
-		// file/url before we start putting it into Pilosa. Not great for memory
-		// usage or smooth performance, but we want to ensure repeatable results
-		// in the simplest way possible.
-		contentBytes, err := ioutil.ReadAll(content)
-		if err != nil {
-			failedURLs[url]++
-			if failedURLs[url] > 10 {
-				log.Fatalf("Unrecoverable failure while fetching url: %v, err: %v. Could not read fully after 10 tries.", url, err)
+		var scan *bufio.Scanner
+		if m.UseReadAll {
+			// we're using ReadAll here to ensure that we can read the entire
+			// file/url before we start putting it into Pilosa. Not great for memory
+			// usage or smooth performance, but we want to ensure repeatable results
+			// in the simplest way possible.
+			contentBytes, err := ioutil.ReadAll(content)
+			if err != nil {
+				failedURLs[url]++
+				if failedURLs[url] > 10 {
+					log.Fatalf("Unrecoverable failure while fetching url: %v, err: %v. Could not read fully after 10 tries.", url, err)
+				}
+				continue
 			}
-			continue
-		}
-		err = content.Close()
-		if err != nil {
-			log.Printf("closing %s, err: %v", url, err)
+			err = content.Close()
+			if err != nil {
+				log.Printf("closing %s, err: %v", url, err)
+			}
+
+			buf := bytes.NewBuffer(contentBytes)
+			scan = bufio.NewScanner(buf)
+		} else {
+			scan = bufio.NewScanner(content)
 		}
 
-		buf := bytes.NewBuffer(contentBytes)
-
-		scan := bufio.NewScanner(buf)
 		// discard header line
 		correctLine := false
 		if scan.Scan() {
@@ -336,7 +342,7 @@ func (m *Main) fetch(urls <-chan string, records chan<- Record) {
 			}
 			records <- Record{Val: record, Type: typ}
 		}
-		err = scan.Err()
+		err := scan.Err()
 		if err != nil {
 			log.Printf("scan error on %s, err: %v", url, err)
 		}


### PR DESCRIPTION
We were using ioutil.ReadAll to ensure that we were able to download an entire
file before starting to parse and ingest it into Pilosa. This is fine if you
have a lot of memory and need perfectly repeatable results, but if you don't
have 32GB of mem and just want to try it, it's not so good. This commit makes it
an option controllable by the use-read-all flag.