### PR TITLE
make the maximum default field range safe for 32 bit arch

### DIFF
--- a/pilosa.go
+++ b/pilosa.go
@@ -87,7 +87,7 @@ func (i *Index) AddValue(frame, field string, col uint64, val int64) {
 				{
 					Name: field,
 					Min:  0,
-					Max:  1 << 32,
+					Max:  1<<31 - 1,
 				},
 			}})
 		if err != nil {


### PR DESCRIPTION
we should probably change the field min and max values to be int64, but this
would be a more invasive change