### PR TITLE
use level translator with kafka, fix bug when restarting level trans

### DIFF
--- a/kafka/integration_test.go
+++ b/kafka/integration_test.go
@@ -39,6 +39,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"net/http"
+	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -225,8 +226,16 @@ func runMain(t *testing.T, allowedFields []string) {
 	m.Topics = []string{kafkaTopic}
 	m.Proxy = ":39485"
 	m.MaxRecords = 1000
+	var err error
+	m.TranslatorDir, err = ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("making temp dir for translation: %v", err)
+	}
+	defer func() {
+		os.RemoveAll(m.TranslatorDir)
+	}()
 
-	err := m.Run()
+	err = m.Run()
 	if err != nil {
 		t.Fatalf("error running: %v", err)
 	}

--- a/leveldb/translator.go
+++ b/leveldb/translator.go
@@ -144,6 +144,11 @@ func NewFieldTranslator(dirname string, field string) (*FieldTranslator, error) 
 	if err != nil {
 		return nil, errors.Wrapf(err, "opening leveldb at %v", dirname+"/"+field+"-id")
 	}
+	iter := mdbs.idMap.NewIterator(nil, nil)
+	if iter.Last() {
+		key := iter.Key()
+		*mdbs.curID = binary.BigEndian.Uint64(key) + 1
+	}
 	mdbs.valMap, err = leveldb.OpenFile(dirname+"/"+field+"-val", &opt.Options{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "opening leveldb at %v", dirname+"/"+field+"-val")

--- a/leveldb/translator_test.go
+++ b/leveldb/translator_test.go
@@ -56,6 +56,10 @@ func TestTranslator(t *testing.T) {
 	if err != nil {
 		t.Fatalf("couldn't get id for hello f1: %v", err)
 	}
+	_, err = bt.GetID("f1", []byte("bloop"))
+	if err != nil {
+		t.Fatalf("getting another id for f1: %v", err)
+	}
 	id2, err := bt.GetID("f2", []byte("hello"))
 	if err != nil {
 		t.Fatalf("couldn't get id for hello in f2: %v", err)
@@ -91,6 +95,12 @@ func TestTranslator(t *testing.T) {
 	bt, err = NewTranslator(levelDir, "f1", "f2")
 	if err != nil {
 		t.Fatalf("couldn't get level translator after closing: %v", err)
+	}
+	// make sure a newly allocated value doesn't start back at id 0
+	idF1newval, err := bt.GetID("f1", []byte("newval"))
+	test.ErrNil(t, err, "get f1 newval")
+	if idF1newval != 2 {
+		t.Fatalf("Got %v for f1:newval", idF1newval)
 	}
 	val, err = bt.Get("f1", id1)
 	test.ErrNil(t, err, `Get("f1", id1)`)


### PR DESCRIPTION
The leveldb translator had a bug where it didn't read what the currently highest
allocated id was on startup which meant that it would start re-allocating from zero.