### PR TITLE
ignore exists field in setup

### DIFF
--- a/pilosa.go
+++ b/pilosa.go
@@ -145,6 +145,10 @@ func NewIntField(index *gopilosa.Index, name string, min, max int64) *gopilosa.F
 // exclusive access to Index before calling.
 func (i *Index) setupField(field *gopilosa.Field) error {
 	fieldName := field.Name()
+	// TODO: implement a more elegant way of ignoring reserved (i.e. internal) fields
+	if fieldName == "exists" {
+		return nil
+	}
 	if _, ok := i.recordChans[fieldName]; !ok {
 		err := i.client.EnsureField(field)
 		if err != nil {


### PR DESCRIPTION
The PDK is currently using the list of fields from the go client `Fields()` method to setup fields for indexing in the `indexer`. This is a problem because the `Fields()` returns the `exists` field in its list, and then the PDK tries to re-create it. That returns an error.

This PR is really a temporary fix, but we should really come up with a better way to handle reserved field names.