### PR TITLE
variety of additions from the last demo

### DIFF
--- a/cmd/userid.go
+++ b/cmd/userid.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"io"
+	"log"
+	"time"
+
+	"github.com/jaffee/commandeer"
+	"github.com/pilosa/pdk/usecase/userid"
+	"github.com/spf13/cobra"
+)
+
+// UseridMain is wrapped by NewUseridCommand and only exported for testing purposes.
+var UseridMain *userid.Main
+
+// NewUseridCommand returns a new cobra command wrapping UseridMain.
+func NewUseridCommand(stdin io.Reader, stdout, stderr io.Writer) *cobra.Command {
+	var err error
+	UseridMain = userid.NewMain()
+	useridCommand := &cobra.Command{
+		Use:   "userid",
+		Short: "generate and index fake user data",
+		Long:  `TODO`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			start := time.Now()
+			err = UseridMain.Run()
+			if err != nil {
+				return err
+			}
+			log.Println("Done: ", time.Since(start))
+			return nil
+		},
+	}
+	flags := useridCommand.Flags()
+	err = commandeer.Flags(flags, UseridMain)
+	if err != nil {
+		panic(err)
+	}
+	return useridCommand
+}
+
+func init() {
+	subcommandFns["userid"] = NewUseridCommand
+}

--- a/fake/user.go
+++ b/fake/user.go
@@ -74,7 +74,7 @@ func (u *UserGenerator) Record() *User {
 		FirstName: u.g.String(8, 10000),
 		LastName:  u.g.String(10, 50000),
 		Allergies: u.genAllergies(),
-		Title:     u.g.String(12, 1000),
+		Title:     titleList[u.r.Intn(len(titleList))],
 	}
 }
 
@@ -89,3 +89,5 @@ func (u *UserGenerator) genAllergies() []string {
 }
 
 var allergyList = []string{"Balsam of Peru", "Egg", "Fish", "Shellfish", "Fruit", "Garlic", "Hot Peppers", "Oats", "Meat", "Milk", "Peanut", "Rice", "Sesame", "Soy", "Sulfites", "Tartrazine", "Tree Nut", "Wheat", "Tetracycline", "Dilantin", "Tegretol", "Penicillin", "Cephalosporins", "Sulfonamides", "Cromolyn", "Sodium", "Nedocromil", "Pollen", "Cat", "Dog", "Insect Sting", "Mold", "Perfume", "Cosmetics", "Latex", "Water", "Nickel", "Gold", "Chromium", "Cobalt Chloride", "Formaldehyde", "Photographic Developers", "Fungicide"}
+
+var titleList = []string{"Specialist", "Director", "Designer", "Analyst", "Consultant", "Manager", "Assistant", "Copywriter", "Strategist", "VP", "Executive", "QC", "CEO", "HR", "Receptionist", "Secretary", "Clerk", "Auditor", "Bookkeeper", "Data Entry", "Computer Scientist", "IT Professional", "UX Designer", "SQL Developer", "Web Developer", "Software Engineer", "DevOps Engineer", "Computer Programmer", "Network Administrator", "Information Security Analyst", "Artificial Intelligence Engineer", "Cloud Architect", "IT Manager", "Technical Specialist", "Application Developer", "CTO", "CIO"}

--- a/fake/user.go
+++ b/fake/user.go
@@ -74,7 +74,7 @@ func (u *UserGenerator) Record() *User {
 		FirstName: u.g.String(8, 10000),
 		LastName:  u.g.String(10, 50000),
 		Allergies: u.genAllergies(),
-		Title:     titleList[u.r.Intn(len(titleList))],
+		Title:     titleList[u.g.Uint64(len(titleList))],
 	}
 }
 

--- a/fake/user_test.go
+++ b/fake/user_test.go
@@ -33,7 +33,7 @@ func TestUserGenerator(t *testing.T) {
 		if rec.Age < 0 || rec.Age > 110 {
 			t.Errorf("Age: %d", rec.Age)
 		}
-		if len(rec.Title) > 12 || len(rec.Title) < 1 {
+		if len(rec.Title) < 1 {
 			t.Errorf("Title got: %s", rec.Title)
 		}
 		titles[rec.Title]++

--- a/mapper.go
+++ b/mapper.go
@@ -194,7 +194,7 @@ func Int64ize(val Literal) int64 {
 // PilosaRecord represents a number of set columns and values in a single Column
 // in Pilosa.
 type PilosaRecord struct {
-	Col  uint64
+	Col  uint64OrString
 	Rows []Row
 	Vals []Val
 }
@@ -219,7 +219,7 @@ func (pr *PilosaRecord) AddRowTime(field string, id uint64, ts time.Time) {
 // PilosaRecord containg the Row).
 type Row struct {
 	Field string
-	ID    uint64
+	ID    uint64OrString
 
 	// Time is the timestamp for the column in Pilosa which is the intersection of
 	// this row and the Column in the PilosaRecord which holds this row.

--- a/pilosa_test.go
+++ b/pilosa_test.go
@@ -60,11 +60,11 @@ func TestSetupPilosa(t *testing.T) {
 		t.Fatalf("SetupPilosa: %v", err)
 	}
 
-	indexer.AddColumn("field1", 0, 0)
-	indexer.AddValue("field3", 0, 97)
-	indexer.AddColumnTimestamp("fieldtime", 0, 0, time.Date(2018, time.February, 22, 9, 0, 0, 0, time.UTC))
-	indexer.AddColumnTimestamp("fieldtime", 2, 0, time.Date(2018, time.February, 24, 9, 0, 0, 0, time.UTC))
-	indexer.AddValue("field3", 0, 100)
+	indexer.AddColumn("field1", uint64(0), uint64(0))
+	indexer.AddValue("field3", uint64(0), 97)
+	indexer.AddColumnTimestamp("fieldtime", uint64(0), uint64(0), time.Date(2018, time.February, 22, 9, 0, 0, 0, time.UTC))
+	indexer.AddColumnTimestamp("fieldtime", uint64(2), uint64(0), time.Date(2018, time.February, 24, 9, 0, 0, 0, time.UTC))
+	indexer.AddValue("field3", uint64(0), 100)
 
 	err = indexer.Close()
 	if err != nil {
@@ -88,8 +88,11 @@ func TestSetupPilosa(t *testing.T) {
 		t.Fatalf("index with wrong name: %v", idx)
 	}
 
-	if len(idxs["newindex"].Fields()) != 4 {
-		t.Fatalf("wrong number of fields: %v", idxs["newindex"].Fields())
+	if len(idxs["newindex"].Fields()) != 5 {
+		t.Errorf("wrong number of fields: %v. Fields:in", len(idxs["newindex"].Fields()))
+		for _, field := range idxs["newindex"].Fields() {
+			t.Logf("%#v\n", field)
+		}
 	}
 
 	idx := schema.Index("newindex")

--- a/pipeline.go
+++ b/pipeline.go
@@ -61,9 +61,9 @@ type RecordMapper interface {
 
 // Indexer puts stuff into Pilosa.
 type Indexer interface {
-	AddColumn(field string, col, row uint64)
+	AddColumn(field string, col, row uint64OrString)
 	AddColumnTimestamp(field string, col, row uint64, ts time.Time)
-	AddValue(field string, col uint64, val int64)
+	AddValue(field string, col uint64OrString, val int64)
 	// AddRowAttr(field string, row uint64, key string, value AttrVal)
 	// AddColAttr(col uint64, key string, value AttrVal)
 	Close() error

--- a/usecase/fakeusers/cmd.go
+++ b/usecase/fakeusers/cmd.go
@@ -1,7 +1,6 @@
 package fakeusers
 
 import (
-	"log"
 	"time"
 
 	gopilosa "github.com/pilosa/go-pilosa"
@@ -12,13 +11,11 @@ import (
 
 // Main holds the options for generating fake data and ingesting it to Pilosa.
 type Main struct {
-	Seed        int64  `help:"Random seed for generating data. -1 will use current nanosecond."`
-	Num         uint64 `help:"Number of records to generate. 0 means infinity."`
-	Framer      pdk.DashField
+	Seed        int64    `help:"Random seed for generating data. -1 will use current nanosecond."`
+	Num         uint64   `help:"Number of records to generate. 0 means infinity."`
 	PilosaHosts []string `help:"Comma separated list of Pilosa hosts and ports."`
 	Index       string   `help:"Pilosa index."`
 	BatchSize   uint     `help:"Batch size for Pilosa imports (latency/throughput tradeoff)."`
-	Proxy       string   `help:"Bind to this address to proxy and translate requests to Pilosa"`
 }
 
 // NewMain returns a new Main.
@@ -28,7 +25,6 @@ func NewMain() *Main {
 		PilosaHosts: []string{"localhost:10101"},
 		Index:       "users",
 		BatchSize:   1000,
-		Proxy:       ":13131",
 	}
 }
 
@@ -40,29 +36,48 @@ func (m *Main) Run() error {
 
 	src := fake.NewUserSource(m.Seed, m.Num)
 
-	parser := pdk.NewDefaultGenericParser()
-
-	mapper := pdk.NewCollapsingMapper()
-	mapper.ColTranslator = nil
-	mapper.Framer = &m.Framer
-
 	schema := gopilosa.NewSchema()
 	idx := schema.Index("users")
 	idx.Field("age", gopilosa.OptFieldTypeInt(0, 112))
-	idx.Field("lastname", gopilosa.OptFieldTypeSet(gopilosa.CacheTypeRanked, 50000))
-	idx.Field("firstname", gopilosa.OptFieldTypeSet(gopilosa.CacheTypeRanked, 10000))
-	idx.Field("title", gopilosa.OptFieldTypeSet(gopilosa.CacheTypeRanked, 1000))
-	idx.Field("allergies", gopilosa.OptFieldTypeSet(gopilosa.CacheTypeRanked, 1000))
+	idx.Field("lastname", gopilosa.OptFieldTypeSet(gopilosa.CacheTypeRanked, 50000), gopilosa.OptFieldKeys(true))
+	idx.Field("firstname", gopilosa.OptFieldTypeSet(gopilosa.CacheTypeRanked, 10000), gopilosa.OptFieldKeys(true))
+	idx.Field("title", gopilosa.OptFieldTypeSet(gopilosa.CacheTypeRanked, 1000), gopilosa.OptFieldKeys(true))
+	idx.Field("allergies", gopilosa.OptFieldTypeSet(gopilosa.CacheTypeRanked, 1000), gopilosa.OptFieldKeys(true))
 
 	indexer, err := pdk.SetupPilosa(m.PilosaHosts, m.Index, schema, m.BatchSize)
 	if err != nil {
 		return errors.Wrap(err, "setting up Pilosa")
 	}
 
-	ingester := pdk.NewIngester(src, parser, mapper, indexer)
-	go func() {
-		err = pdk.StartMappingProxy(m.Proxy, pdk.NewPilosaForwarder(m.PilosaHosts[0], mapper.Translator))
-		log.Fatal(errors.Wrap(err, "starting mapping proxy"))
-	}()
-	return errors.Wrap(ingester.Run(), "running ingester")
+	for rec, err := src.Record(); err == nil; rec, err = src.Record() {
+		pr := parseUserRecord(rec.(*fake.User))
+		ingestPilosaRecord(indexer, pr)
+	}
+	return errors.Wrap(indexer.Close(), "closing indexer")
+}
+
+func parseUserRecord(u *fake.User) pdk.PilosaRecord {
+	ret := pdk.PilosaRecord{
+		Col: u.ID,
+		Rows: []pdk.Row{
+			{Field: "firstname", ID: u.FirstName},
+			{Field: "lastname", ID: u.LastName},
+			{Field: "title", ID: u.Title},
+		},
+		Vals: []pdk.Val{{Field: "age", Value: int64(u.Age)}},
+	}
+	for _, a := range u.Allergies {
+		ret.Rows = append(ret.Rows, pdk.Row{Field: "allergies", ID: a})
+	}
+	return ret
+}
+
+func ingestPilosaRecord(indexer pdk.Indexer, pr pdk.PilosaRecord) {
+	for _, row := range pr.Rows {
+		indexer.AddColumn(row.Field, pr.Col, row.ID)
+	}
+	for _, val := range pr.Vals {
+		indexer.AddValue(val.Field, pr.Col, val.Value)
+	}
+
 }

--- a/usecase/fakeusers/cmd_test.go
+++ b/usecase/fakeusers/cmd_test.go
@@ -1,0 +1,60 @@
+package fakeusers_test
+
+import (
+	"testing"
+
+	gopilosa "github.com/pilosa/go-pilosa"
+	"github.com/pilosa/pilosa/test"
+
+	"github.com/pilosa/pdk/usecase/fakeusers"
+)
+
+func TestFakeUsers(t *testing.T) {
+	cluster := test.MustRunCluster(t, 3)
+	client, err := gopilosa.NewClient([]string{cluster[0].URL(), cluster[1].URL(), cluster[2].URL()})
+	if err != nil {
+		t.Fatalf("getting new client: %v", err)
+	}
+
+	main := fakeusers.NewMain()
+
+	main.Num = 1000
+	main.PilosaHosts = []string{cluster[0].URL(), cluster[1].URL(), cluster[2].URL()}
+
+	main.Run()
+
+	_, titleField := GetField(t, client, "users", "title")
+
+	resp := query(t, client, titleField.TopN(10))
+	items := resp.Result().CountItems()
+	if len(items[0].Key) < 1 {
+		t.Fatalf("should have a key: %#v", items[0])
+	}
+	if items[0].Count < items[1].Count || items[1].Count < 1 {
+		t.Fatalf("bad counts: %v", items)
+	}
+
+}
+
+func query(t *testing.T, c *gopilosa.Client, query gopilosa.PQLQuery) *gopilosa.QueryResponse {
+	resp, err := c.Query(query)
+	if err != nil {
+		t.Fatalf("querying: %v", err)
+	}
+	return resp
+}
+
+func GetField(t *testing.T, c *gopilosa.Client, index, field string) (*gopilosa.Index, *gopilosa.Field) {
+	schema, err := c.Schema()
+	if err != nil {
+		t.Fatalf("getting schema: %v", err)
+	}
+	idx := schema.Index(index)
+	fram := idx.Field(field)
+	err = c.SyncSchema(schema)
+	if err != nil {
+		t.Fatalf("syncing schema: %v", err)
+	}
+
+	return idx, fram
+}

--- a/usecase/taxi/Makefile
+++ b/usecase/taxi/Makefile
@@ -6,3 +6,6 @@ install:
 
 run: install
 	nohup pdk taxi -f ./greenAndYellowUrls.txt --pilosa $PILOSA_IP:10101 -b 1000000 -c 6 -e 2 &> taxi.out &
+
+logs:
+	tail -f taxi.out

--- a/usecase/taxi/Makefile
+++ b/usecase/taxi/Makefile
@@ -1,0 +1,8 @@
+PILOSA_IP=""
+
+install:
+	cd ../..; \
+	make install
+
+run: install
+	nohup pdk taxi -f ./greenAndYellowUrls.txt --pilosa $PILOSA_IP:10101 -b 1000000 -c 6 -e 2 &> taxi.out &

--- a/usecase/taxi/user.go
+++ b/usecase/taxi/user.go
@@ -11,7 +11,7 @@ type userGetter struct {
 func newUserGetter(seed int) *userGetter {
 	r := rand.New(rand.NewSource(int64(seed)))
 	return &userGetter{
-		z: rand.NewZipf(r, 2, 1, 5000000), // zipfian distribution over 5 million users
+		z: rand.NewZipf(r, 1.1, 1024, 5000000), // zipfian distribution over 5 million users
 	}
 }
 

--- a/usecase/taxi/user_test.go
+++ b/usecase/taxi/user_test.go
@@ -1,0 +1,25 @@
+package taxi
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestUserGetter(t *testing.T) {
+	ug := newUserGetter(0)
+	results := make(map[uint64]int)
+	for i := 0; i < 120000000; i++ {
+		results[ug.ID()]++
+	}
+
+	fmt.Println("Number of users generated", len(results))
+	last := uint64(0)
+	for i := uint64(0); i < 5000000; i += 100000 {
+		if results[i] > 0 {
+			last = i
+		}
+		fmt.Printf("%d: %d\n", i, results[i])
+	}
+	fmt.Println("last:", last, " results[last] ", results[last])
+
+}

--- a/usecase/userid/cmd.go
+++ b/usecase/userid/cmd.go
@@ -1,0 +1,67 @@
+package userid
+
+import (
+	"math/rand"
+	"time"
+
+	gopilosa "github.com/pilosa/go-pilosa"
+	"github.com/pilosa/pdk"
+	"github.com/pkg/errors"
+)
+
+// Main holds the options for generating fake data and ingesting it to Pilosa.
+type Main struct {
+	Seed        int64    `help:"Random seed for generating data. -1 will use current nanosecond."`
+	Num         uint64   `help:"Number of records to generate. 0 means infinity."`
+	PilosaHosts []string `help:"Comma separated list of Pilosa hosts and ports."`
+	Index       string   `help:"Pilosa index."`
+	BatchSize   uint     `help:"Batch size for Pilosa imports (latency/throughput tradeoff)."`
+}
+
+// NewMain returns a new Main.
+func NewMain() *Main {
+	return &Main{
+		Num:         1266087512,
+		PilosaHosts: []string{"localhost:10101"},
+		Index:       "taxi",
+		BatchSize:   100000,
+	}
+}
+
+// Run begins generating data and ingesting it to Pilosa.
+func (m *Main) Run() error {
+	if m.Seed == -1 {
+		m.Seed = time.Now().UnixNano()
+	}
+
+	schema := gopilosa.NewSchema()
+	idx := schema.Index(m.Index)
+	idx.Field("user_id2", gopilosa.OptFieldTypeSet(gopilosa.CacheTypeRanked, 50000))
+	indexer, err := pdk.SetupPilosa(m.PilosaHosts, m.Index, schema, m.BatchSize)
+	if err != nil {
+		return errors.Wrap(err, "setting up Pilosa")
+	}
+
+	ug := newUserGetter(m.Seed)
+
+	for i := uint64(0); i < m.Num; i++ {
+		indexer.AddColumn("user_id2", i, ug.ID())
+	}
+
+	return errors.Wrap(indexer.Close(), "closing indexer")
+}
+
+type userGetter struct {
+	z *rand.Zipf
+}
+
+func newUserGetter(seed int64) *userGetter {
+	r := rand.New(rand.NewSource(seed))
+	return &userGetter{
+		z: rand.NewZipf(r, 1.1, 1024, 5000000), // zipfian distribution over 5 million users
+	}
+}
+
+func (u *userGetter) ID() uint64 {
+	return u.z.Uint64()
+}


### PR DESCRIPTION
adds a command which generates fake users, adds a command which generates user ids (e.g. to associate with taxi rides) with a semi-realistic distribution. 

adds some support to pdk indexer for string keys as rows or columns. This support is used by the fake users command.