### PR TITLE
re-add all the user stuff.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,13 +11,13 @@
   branch = "master"
   name = "github.com/DataDog/datadog-go"
   packages = ["statsd"]
-  revision = "ef3a9daf849df2d7ee3bbf13808dfb481069a773"
+  revision = "281ae9f2d8950e694e810c78daf74201d869b0d0"
 
 [[projects]]
   name = "github.com/Shopify/sarama"
   packages = ["."]
-  revision = "35324cf48e33d8260e1c7c18854465a904ade249"
-  version = "v1.17.0"
+  revision = "ec843464b50d4c8b56403ec9d589cf41ea30e722"
+  version = "v1.19.0"
 
 [[projects]]
   name = "github.com/StackExchange/wmi"
@@ -29,7 +29,7 @@
   branch = "master"
   name = "github.com/armon/go-metrics"
   packages = ["."]
-  revision = "3c58d8115a78a6879e5df75ae900846768d36895"
+  revision = "f0300d1749da6fa982027e449ec0c7a145510c3c"
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
@@ -51,6 +51,8 @@
     "aws/request",
     "aws/session",
     "aws/signer/v4",
+    "internal/ini",
+    "internal/s3err",
     "internal/sdkio",
     "internal/sdkrand",
     "internal/sdkuri",
@@ -66,8 +68,8 @@
     "service/s3",
     "service/sts"
   ]
-  revision = "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4"
-  version = "v1.14.33"
+  revision = "ab1e4ad20b12ab0df8a825805de3e48ad6c59d28"
+  version = "v1.15.75"
 
 [[projects]]
   name = "github.com/boltdb/bolt"
@@ -78,20 +80,20 @@
 [[projects]]
   name = "github.com/bsm/sarama-cluster"
   packages = ["."]
-  revision = "cf455bc755fe41ac9bb2861e7a961833d9c2ecc3"
-  version = "v2.1.13"
+  revision = "c618e605e15c0d7535f6c96ff8efbb0dba4fd66c"
+  version = "v2.1.15"
 
 [[projects]]
   name = "github.com/cespare/xxhash"
   packages = ["."]
-  revision = "5c37fe3735342a2e0d01c87a907579987c8936cc"
-  version = "v1.0.0"
+  revision = "569f7c8abf1f58d9043ab804d364483cb1c853b6"
+  version = "v1.1.0"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
-  version = "v1.1.0"
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
 
 [[projects]]
   name = "github.com/eapache/go-resiliency"
@@ -103,7 +105,7 @@
   branch = "master"
   name = "github.com/eapache/go-xerial-snappy"
   packages = ["."]
-  revision = "040cc1a32f578808623071247fdbd5cc43f37f5f"
+  revision = "776d5712da21bc4762676d614db1d8a64f4238b0"
 
 [[projects]]
   name = "github.com/eapache/queue"
@@ -124,12 +126,6 @@
   version = "v1.4.7"
 
 [[projects]]
-  name = "github.com/go-ini/ini"
-  packages = ["."]
-  revision = "358ee7663966325963d4e8b2e1fbd570c5195153"
-  version = "v1.38.1"
-
-[[projects]]
   name = "github.com/go-ole/go-ole"
   packages = [
     ".",
@@ -147,8 +143,8 @@
 [[projects]]
   name = "github.com/golang/protobuf"
   packages = ["proto"]
-  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
-  version = "v1.1.0"
+  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
@@ -175,16 +171,16 @@
   version = "v1.6.2"
 
 [[projects]]
-  branch = "master"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
-  revision = "d6c0cd88035724dd42e0f335ae30161c20575ecc"
+  revision = "8a6fb523712970c966eefc6b39ed2c5e74880354"
+  version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/hashicorp/go-immutable-radix"
   packages = ["."]
-  revision = "7f3cd4390caab3250a57f30efdb2a65dd7649ecf"
+  revision = "27df80928bb34bb1b0d6d0e01b9e679902e7a6b5"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -193,10 +189,10 @@
   revision = "fa3f63826f7c23912c15263591e65d54d080b458"
 
 [[projects]]
-  branch = "master"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
-  revision = "3d5d8f294aa03d8e98859feac328afbdf1ae0703"
+  revision = "886a7fbe3eb1c874d46f623bfa70af45f425b3d1"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -205,13 +201,12 @@
   revision = "6d291a969b86c4b633730bfc6b8b9d64c3aafed9"
 
 [[projects]]
-  branch = "master"
   name = "github.com/hashicorp/golang-lru"
   packages = ["simplelru"]
-  revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
+  revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
+  version = "v0.5.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -225,7 +220,8 @@
     "json/scanner",
     "json/token"
   ]
-  revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
+  revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/hashicorp/memberlist"
@@ -256,8 +252,8 @@
 [[projects]]
   name = "github.com/linkedin/goavro"
   packages = ["."]
-  revision = "fa8f6a30176ce945e115db0afad95ede93725eec"
-  version = "v2.3.0"
+  revision = "1beee2a7408830381d63899b90404fccd4d48c58"
+  version = "v2.7.0"
 
 [[projects]]
   name = "github.com/magiconair/properties"
@@ -268,20 +264,20 @@
 [[projects]]
   name = "github.com/miekg/dns"
   packages = ["."]
-  revision = "5a2b9fab83ff0f8bfc99684bd5f43a37abe560f1"
-  version = "v1.0.8"
+  revision = "7064f7248f5fa5fd79382a76328b4e200b79e4ae"
+  version = "v1.0.15"
 
 [[projects]]
-  branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  revision = "f15292f7a699fcc1a38a80977f80a046874ba8ac"
+  revision = "3536a929edddb9a5b34bd6861dc4a9647cb459fe"
+  version = "v1.1.2"
 
 [[projects]]
   branch = "master"
   name = "github.com/mmcloughlin/geohash"
   packages = ["."]
-  revision = "3b756d8ac3d9d9b1217f28a9e6cbba629e1815b3"
+  revision = "f7f2bcae3294530249c63fcb6fb6d5e83eee4e73"
 
 [[projects]]
   name = "github.com/pelletier/go-toml"
@@ -295,8 +291,8 @@
     ".",
     "internal/xxh32"
   ]
-  revision = "1958fd8fff7f115e79725b1288e0b878b3e06b00"
-  version = "v2.0.3"
+  revision = "635575b42742856941dbc767b44905bb9ba083f6"
+  version = "v2.0.7"
 
 [[projects]]
   branch = "master"
@@ -305,7 +301,7 @@
     ".",
     "gopilosa_pbuf"
   ]
-  revision = "f619925970a36c849d0e46c1befa6ca226a89240"
+  revision = "796d4f7d7f3b5a363be2562e4d1aab2fb6324404"
 
 [[projects]]
   branch = "master"
@@ -329,7 +325,7 @@
     "test",
     "toml"
   ]
-  revision = "ada9857f350dee69fdb314e8d5a892337813571c"
+  revision = "faac64dc999c744be11a8f808d38786f5353ea5d"
 
 [[projects]]
   name = "github.com/pkg/errors"
@@ -341,7 +337,7 @@
   branch = "master"
   name = "github.com/rcrowley/go-metrics"
   packages = ["."]
-  revision = "e2704e165165ec55d062f5919b4b29494e9fa790"
+  revision = "3113b8401b8a98917cde58f8bbd42a1b1c03b1fd"
 
 [[projects]]
   name = "github.com/satori/go.uuid"
@@ -363,8 +359,8 @@
     "mem",
     "process"
   ]
-  revision = "4a180b209f5f494e5923cfce81ea30ba23915877"
-  version = "v2.18.06"
+  revision = "3ec50d2876a36047b2ca39f955ba88fb7a455e92"
+  version = "v2.18.10"
 
 [[projects]]
   name = "github.com/spf13/afero"
@@ -372,14 +368,14 @@
     ".",
     "mem"
   ]
-  revision = "787d034dfe70e44075ccc060d346146ef53270ad"
-  version = "v1.1.1"
+  revision = "d40851caa0d747393da1ffb28f7f9d8b4eeffebd"
+  version = "v1.1.2"
 
 [[projects]]
   name = "github.com/spf13/cast"
   packages = ["."]
-  revision = "8965335b8c7107321228e3e3702cab9832751bac"
-  version = "v1.2.0"
+  revision = "8c9545af88b134710ab1cd196795e7f2388358d7"
+  version = "v1.3.0"
 
 [[projects]]
   name = "github.com/spf13/cobra"
@@ -388,22 +384,22 @@
   version = "v0.0.3"
 
 [[projects]]
-  branch = "master"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
-  revision = "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394"
+  revision = "4a4406e478ca629068e7768fc33f3f044173c0a6"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/spf13/pflag"
   packages = ["."]
-  revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
-  version = "v1.0.1"
+  revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
+  version = "v1.0.3"
 
 [[projects]]
   name = "github.com/spf13/viper"
   packages = ["."]
-  revision = "b5e8006cbee93ec955a89ab31e0e3ce3204f3736"
-  version = "v1.0.2"
+  revision = "2c12c60302a5a0e62ee102ca9bc996277c2f64f5"
+  version = "v1.2.1"
 
 [[projects]]
   branch = "master"
@@ -422,7 +418,7 @@
     "leveldb/table",
     "leveldb/util"
   ]
-  revision = "c4c61651e9e37fa117f53c5a906d3b63090d8445"
+  revision = "f9080354173f192dfc8821931eacf9cfd6819253"
 
 [[projects]]
   branch = "master"
@@ -431,26 +427,25 @@
     "ed25519",
     "ed25519/internal/edwards25519"
   ]
-  revision = "c126467f60eb25f8f27e5a981f32a87e3965053f"
+  revision = "3d3f9f413869b949e48070b5bc593aa22cc2b8f2"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = [
     "bpf",
-    "context",
     "internal/iana",
     "internal/socket",
     "ipv4",
     "ipv6"
   ]
-  revision = "3673e40ba22529d22c3fd7c93e97b0ce50fa7bdd"
+  revision = "88d92db4c548972d942ac2a3531a8a9a34c82ca6"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sync"
   packages = ["errgroup"]
-  revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
+  revision = "42b317875d0fa942474b76e1b46a6060d720ae6e"
 
 [[projects]]
   branch = "master"
@@ -459,7 +454,7 @@
     "unix",
     "windows"
   ]
-  revision = "e072cadbbdc8dd3d3ffa82b8b4b9304c261d9311"
+  revision = "66b7b1311ac80bbafcd2daeef9a5e6e2cd1e2399"
 
 [[projects]]
   name = "golang.org/x/text"

--- a/cmd/fakeusers.go
+++ b/cmd/fakeusers.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"io"
+	"log"
+	"time"
+
+	"github.com/jaffee/commandeer"
+	"github.com/pilosa/pdk/usecase/fakeusers"
+	"github.com/spf13/cobra"
+)
+
+// FakeusersMain is wrapped by NewFakeusersCommand and only exported for testing purposes.
+var FakeusersMain *fakeusers.Main
+
+// NewFakeusersCommand returns a new cobra command wrapping FakeusersMain.
+func NewFakeusersCommand(stdin io.Reader, stdout, stderr io.Writer) *cobra.Command {
+	var err error
+	FakeusersMain = fakeusers.NewMain()
+	fakeusersCommand := &cobra.Command{
+		Use:   "fakeusers",
+		Short: "generate and index fake user data",
+		Long:  `TODO`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			start := time.Now()
+			err = FakeusersMain.Run()
+			if err != nil {
+				return err
+			}
+			log.Println("Done: ", time.Since(start))
+			select {}
+		},
+	}
+	flags := fakeusersCommand.Flags()
+	err = commandeer.Flags(flags, FakeusersMain)
+	if err != nil {
+		panic(err)
+	}
+	return fakeusersCommand
+}
+
+func init() {
+	subcommandFns["fakeusers"] = NewFakeusersCommand
+}

--- a/cmd/userid.go
+++ b/cmd/userid.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"io"
+	"log"
+	"time"
+
+	"github.com/jaffee/commandeer"
+	"github.com/pilosa/pdk/usecase/userid"
+	"github.com/spf13/cobra"
+)
+
+// UseridMain is wrapped by NewUseridCommand and only exported for testing purposes.
+var UseridMain *userid.Main
+
+// NewUseridCommand returns a new cobra command wrapping UseridMain.
+func NewUseridCommand(stdin io.Reader, stdout, stderr io.Writer) *cobra.Command {
+	var err error
+	UseridMain = userid.NewMain()
+	useridCommand := &cobra.Command{
+		Use:   "userid",
+		Short: "generate and index fake user data",
+		Long:  `TODO`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			start := time.Now()
+			err = UseridMain.Run()
+			if err != nil {
+				return err
+			}
+			log.Println("Done: ", time.Since(start))
+			return nil
+		},
+	}
+	flags := useridCommand.Flags()
+	err = commandeer.Flags(flags, UseridMain)
+	if err != nil {
+		panic(err)
+	}
+	return useridCommand
+}
+
+func init() {
+	subcommandFns["userid"] = NewUseridCommand
+}

--- a/fake/user.go
+++ b/fake/user.go
@@ -1,0 +1,93 @@
+package fake
+
+import (
+	"io"
+	"math"
+	"math/rand"
+	"sync/atomic"
+
+	"github.com/pilosa/pdk/fake/gen"
+)
+
+// UserSource is a pdk.Source which generates fake user data.
+type UserSource struct {
+	max uint64
+	n   *uint64
+	ug  *UserGenerator
+}
+
+// NewUserSource creates a new Source with the given random seed. Using the same
+// seed should give the same series of events on a given version of Go.
+func NewUserSource(seed int64, max uint64) *UserSource {
+	if max == 0 {
+		max = math.MaxUint64
+	}
+	var n uint64
+	s := &UserSource{
+		n:   &n,
+		max: max,
+		ug:  NewUserGenerator(seed),
+	}
+
+	return s
+}
+
+// Record implements pdk.Source and returns a randomly generated user.
+func (s *UserSource) Record() (interface{}, error) {
+	next := atomic.AddUint64(s.n, 1)
+	if next > s.max {
+		return nil, io.EOF
+	}
+	user := s.ug.Record()
+	user.ID = next - 1
+	return user, nil
+}
+
+// User is a theoretical user type.
+type User struct {
+	ID        uint64
+	Age       int
+	FirstName string
+	LastName  string
+	Allergies []string
+	Title     string
+}
+
+// UserGenerator generates fake Users.
+type UserGenerator struct {
+	g *gen.Generator
+	r *rand.Rand
+}
+
+// NewUserGenerator initializes a new UserGenerator.
+func NewUserGenerator(seed int64) *UserGenerator {
+	return &UserGenerator{
+		g: gen.NewGenerator(seed),
+		r: rand.New(rand.NewSource(seed)),
+	}
+}
+
+// Record returns a random User record with realistic-ish values.
+func (u *UserGenerator) Record() *User {
+	return &User{
+		Age:       u.r.Intn(110),
+		FirstName: u.g.String(8, 10000),
+		LastName:  u.g.String(10, 50000),
+		Allergies: u.genAllergies(),
+		Title:     titleList[u.g.Uint64(len(titleList))],
+	}
+}
+
+func (u *UserGenerator) genAllergies() []string {
+	n := u.g.Uint64(len(allergyList) - 1)
+	nums := u.r.Perm(len(allergyList))
+	allergies := make([]string, n)
+	for i := 0; i < int(n); i++ {
+		allergies[i] = allergyList[nums[i]]
+	}
+	return allergies
+}
+
+var allergyList = []string{"Balsam of Peru", "Egg", "Fish", "Shellfish", "Fruit", "Garlic", "Hot Peppers", "Oats", "Meat", "Milk", "Peanut", "Rice", "Sesame", "Soy", "Sulfites", "Tartrazine", "Tree Nut", "Wheat", "Tetracycline", "Dilantin", "Tegretol", "Penicillin", "Cephalosporins", "Sulfonamides", "Cromolyn", "Sodium", "Nedocromil", "Pollen", "Cat", "Dog", "Insect Sting", "Mold", "Perfume", "Cosmetics", "Latex", "Water", "Nickel", "Gold", "Chromium", "Cobalt Chloride", "Formaldehyde", "Photographic Developers", "Fungicide"}
+
+var titleList = []string{"Specialist", "Director", "Designer", "Analyst", "Consultant", "Manager", "Assistant", "Copywriter", "Strategist", "VP", "Executive", "QC", "CEO", "HR", "Receptionist", "Secretary", "Clerk", "Auditor", "Bookkeeper", "Data Entry", "Computer Scientist", "IT Professional", "UX Designer", "SQL Developer", "Web Developer", "Software Engineer", "DevOps Engineer", "Computer Programmer", "Network Administrator", "Information Security Analyst", "Artificial Intelligence Engineer", "Cloud Architect", "IT Manager", "Technical Specialist", "Application Developer", "CTO", "CIO"}

--- a/fake/user_test.go
+++ b/fake/user_test.go
@@ -1,0 +1,61 @@
+package fake
+
+import (
+	"io"
+	"testing"
+)
+
+func TestUserGenerator(t *testing.T) {
+	us := NewUserSource(111, 1000)
+
+	fnames := make(map[string]int)
+	lnames := make(map[string]int)
+	titles := make(map[string]int)
+	allergyLens := make(map[int]int)
+
+	for i := 0; i < 1000; i++ {
+		r, err := us.Record()
+		if err != nil {
+			t.Fatalf("unexpected error getting record: %v", err)
+		}
+		rec := r.(*User)
+		if rec.ID != uint64(i) {
+			t.Errorf("ID exp: %d, got: %d", i, rec.ID)
+		}
+		if len(rec.FirstName) > 8 || len(rec.FirstName) < 1 {
+			t.Errorf("FirstName got: %s", rec.FirstName)
+		}
+		fnames[rec.FirstName]++
+		if len(rec.LastName) > 10 || len(rec.LastName) < 1 {
+			t.Errorf("LastName got: %s", rec.LastName)
+		}
+		lnames[rec.LastName]++
+		if rec.Age < 0 || rec.Age > 110 {
+			t.Errorf("Age: %d", rec.Age)
+		}
+		if len(rec.Title) < 1 {
+			t.Errorf("Title got: %s", rec.Title)
+		}
+		titles[rec.Title]++
+		allergyLens[len(rec.Allergies)]++
+		allergies := make(map[string]struct{})
+		for _, aller := range rec.Allergies {
+			if _, ok := allergies[aller]; ok {
+				t.Errorf("got the same allergy twice: %s, record: %d", aller, rec.ID)
+			}
+			allergies[aller] = struct{}{}
+		}
+	}
+
+	if len(titles) >= len(fnames) || len(fnames) >= len(lnames) {
+		t.Errorf("unexpected distribution of strings: %d, %d, %d", len(titles), len(fnames), len(lnames))
+	}
+
+	if len(allergyLens) < 25 {
+		t.Errorf("expected a wider variety of allergy lengths: %v", allergyLens)
+	}
+
+	if _, err := us.Record(); err != io.EOF {
+		t.Fatalf("expected io.EOF, but got %v", err)
+	}
+}

--- a/mapper.go
+++ b/mapper.go
@@ -194,7 +194,7 @@ func Int64ize(val Literal) int64 {
 // PilosaRecord represents a number of set columns and values in a single Column
 // in Pilosa.
 type PilosaRecord struct {
-	Col  uint64
+	Col  uint64OrString
 	Rows []Row
 	Vals []Val
 }
@@ -219,7 +219,7 @@ func (pr *PilosaRecord) AddRowTime(field string, id uint64, ts time.Time) {
 // PilosaRecord containg the Row).
 type Row struct {
 	Field string
-	ID    uint64
+	ID    uint64OrString
 
 	// Time is the timestamp for the column in Pilosa which is the intersection of
 	// this row and the Column in the PilosaRecord which holds this row.

--- a/pilosa.go
+++ b/pilosa.go
@@ -33,6 +33,7 @@
 package pdk
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"sync"
@@ -69,11 +70,35 @@ func (i *Index) AddColumnTimestamp(field string, row, col uint64, ts time.Time) 
 }
 
 // AddColumn adds a column to be imported to Pilosa.
-func (i *Index) AddColumn(field string, col uint64, row uint64) {
+func (i *Index) AddColumn(field string, col, row uint64OrString) {
 	i.addColumn(field, col, row, 0)
 }
 
-func (i *Index) addColumn(fieldName string, col uint64, row uint64, ts int64) {
+type uint64OrString interface{}
+
+func uint64Cast(u uint64OrString) uint64 {
+	ret, _ := u.(uint64)
+	return ret
+}
+
+func stringCast(u uint64OrString) string {
+	ret, _ := u.(string)
+	return ret
+}
+
+func validUint64OrString(u uint64OrString) bool {
+	if _, ok := u.(uint64); !ok {
+		if _, ok := u.(string); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (i *Index) addColumn(fieldName string, col uint64OrString, row uint64OrString, ts int64) {
+	if !validUint64OrString(col) || !validUint64OrString(row) {
+		panic(fmt.Sprintf("a %T and a %T were passed, both must be either uint64 or string", col, row))
+	}
 	var c chanRecordIterator
 	var ok bool
 	i.lock.RLock()
@@ -95,13 +120,20 @@ func (i *Index) addColumn(fieldName string, col uint64, row uint64, ts int64) {
 	} else {
 		i.lock.RUnlock()
 	}
-	c <- gopilosa.Column{RowID: row, ColumnID: col, Timestamp: ts}
+	c <- gopilosa.Column{
+		RowID: uint64Cast(row), ColumnID: uint64Cast(col),
+		RowKey: stringCast(row), ColumnKey: stringCast(col),
+		Timestamp: ts}
 }
 
 // AddValue adds a value to be imported to Pilosa.
-func (i *Index) AddValue(fieldName string, col uint64, val int64) {
+func (i *Index) AddValue(fieldName string, col uint64OrString, val int64) {
 	var c chanRecordIterator
 	var ok bool
+
+	if !validUint64OrString(col) {
+		panic(fmt.Sprintf("a %T was passed, must be eithe uint64 or string", col))
+	}
 
 	i.lock.RLock()
 	if c, ok = i.recordChans[fieldName]; !ok {
@@ -118,7 +150,7 @@ func (i *Index) AddValue(fieldName string, col uint64, val int64) {
 	} else {
 		i.lock.RUnlock()
 	}
-	c <- gopilosa.FieldValue{ColumnID: col, Value: val}
+	c <- gopilosa.FieldValue{ColumnID: uint64Cast(col), ColumnKey: stringCast(col), Value: val}
 }
 
 // Close ensures that all ongoing imports have finished and cleans up internal
@@ -158,7 +190,7 @@ func (i *Index) setupField(field *gopilosa.Field) error {
 		i.importWG.Add(1)
 		go func(fram *gopilosa.Field, cbi chanRecordIterator) {
 			defer i.importWG.Done()
-			err := i.client.ImportField(fram, cbi, gopilosa.OptImportStrategy(gopilosa.BatchImport), gopilosa.OptImportBatchSize(int(i.batchSize)))
+			err := i.client.ImportField(fram, cbi, gopilosa.OptImportBatchSize(int(i.batchSize)))
 			if err != nil {
 				log.Println(errors.Wrapf(err, "starting field import for %v", fieldName))
 			}

--- a/pilosa_test.go
+++ b/pilosa_test.go
@@ -60,11 +60,11 @@ func TestSetupPilosa(t *testing.T) {
 		t.Fatalf("SetupPilosa: %v", err)
 	}
 
-	indexer.AddColumn("field1", 0, 0)
-	indexer.AddValue("field3", 0, 97)
-	indexer.AddColumnTimestamp("fieldtime", 0, 0, time.Date(2018, time.February, 22, 9, 0, 0, 0, time.UTC))
-	indexer.AddColumnTimestamp("fieldtime", 2, 0, time.Date(2018, time.February, 24, 9, 0, 0, 0, time.UTC))
-	indexer.AddValue("field3", 0, 100)
+	indexer.AddColumn("field1", uint64(0), uint64(0))
+	indexer.AddValue("field3", uint64(0), 97)
+	indexer.AddColumnTimestamp("fieldtime", uint64(0), uint64(0), time.Date(2018, time.February, 22, 9, 0, 0, 0, time.UTC))
+	indexer.AddColumnTimestamp("fieldtime", uint64(2), uint64(0), time.Date(2018, time.February, 24, 9, 0, 0, 0, time.UTC))
+	indexer.AddValue("field3", uint64(0), 100)
 
 	err = indexer.Close()
 	if err != nil {
@@ -88,8 +88,11 @@ func TestSetupPilosa(t *testing.T) {
 		t.Fatalf("index with wrong name: %v", idx)
 	}
 
-	if len(idxs["newindex"].Fields()) != 4 {
-		t.Fatalf("wrong number of fields: %v", idxs["newindex"].Fields())
+	if len(idxs["newindex"].Fields()) != 5 {
+		t.Errorf("wrong number of fields: %v. Fields:in", len(idxs["newindex"].Fields()))
+		for _, field := range idxs["newindex"].Fields() {
+			t.Logf("%#v\n", field)
+		}
 	}
 
 	idx := schema.Index("newindex")

--- a/pipeline.go
+++ b/pipeline.go
@@ -61,9 +61,9 @@ type RecordMapper interface {
 
 // Indexer puts stuff into Pilosa.
 type Indexer interface {
-	AddColumn(field string, col, row uint64)
+	AddColumn(field string, col, row uint64OrString)
 	AddColumnTimestamp(field string, col, row uint64, ts time.Time)
-	AddValue(field string, col uint64, val int64)
+	AddValue(field string, col uint64OrString, val int64)
 	// AddRowAttr(field string, row uint64, key string, value AttrVal)
 	// AddColAttr(col uint64, key string, value AttrVal)
 	Close() error

--- a/usecase/fakeusers/cmd.go
+++ b/usecase/fakeusers/cmd.go
@@ -1,0 +1,83 @@
+package fakeusers
+
+import (
+	"time"
+
+	gopilosa "github.com/pilosa/go-pilosa"
+	"github.com/pilosa/pdk"
+	"github.com/pilosa/pdk/fake"
+	"github.com/pkg/errors"
+)
+
+// Main holds the options for generating fake data and ingesting it to Pilosa.
+type Main struct {
+	Seed        int64    `help:"Random seed for generating data. -1 will use current nanosecond."`
+	Num         uint64   `help:"Number of records to generate. 0 means infinity."`
+	PilosaHosts []string `help:"Comma separated list of Pilosa hosts and ports."`
+	Index       string   `help:"Pilosa index."`
+	BatchSize   uint     `help:"Batch size for Pilosa imports (latency/throughput tradeoff)."`
+}
+
+// NewMain returns a new Main.
+func NewMain() *Main {
+	return &Main{
+		Num:         0,
+		PilosaHosts: []string{"localhost:10101"},
+		Index:       "users",
+		BatchSize:   1000,
+	}
+}
+
+// Run begins generating data and ingesting it to Pilosa.
+func (m *Main) Run() error {
+	if m.Seed == -1 {
+		m.Seed = time.Now().UnixNano()
+	}
+
+	src := fake.NewUserSource(m.Seed, m.Num)
+
+	schema := gopilosa.NewSchema()
+	idx := schema.Index("users")
+	idx.Field("age", gopilosa.OptFieldTypeInt(0, 112))
+	idx.Field("lastname", gopilosa.OptFieldTypeSet(gopilosa.CacheTypeRanked, 50000), gopilosa.OptFieldKeys(true))
+	idx.Field("firstname", gopilosa.OptFieldTypeSet(gopilosa.CacheTypeRanked, 10000), gopilosa.OptFieldKeys(true))
+	idx.Field("title", gopilosa.OptFieldTypeSet(gopilosa.CacheTypeRanked, 1000), gopilosa.OptFieldKeys(true))
+	idx.Field("allergies", gopilosa.OptFieldTypeSet(gopilosa.CacheTypeRanked, 1000), gopilosa.OptFieldKeys(true))
+
+	indexer, err := pdk.SetupPilosa(m.PilosaHosts, m.Index, schema, m.BatchSize)
+	if err != nil {
+		return errors.Wrap(err, "setting up Pilosa")
+	}
+
+	for rec, err := src.Record(); err == nil; rec, err = src.Record() {
+		pr := parseUserRecord(rec.(*fake.User))
+		ingestPilosaRecord(indexer, pr)
+	}
+	return errors.Wrap(indexer.Close(), "closing indexer")
+}
+
+func parseUserRecord(u *fake.User) pdk.PilosaRecord {
+	ret := pdk.PilosaRecord{
+		Col: u.ID,
+		Rows: []pdk.Row{
+			{Field: "firstname", ID: u.FirstName},
+			{Field: "lastname", ID: u.LastName},
+			{Field: "title", ID: u.Title},
+		},
+		Vals: []pdk.Val{{Field: "age", Value: int64(u.Age)}},
+	}
+	for _, a := range u.Allergies {
+		ret.Rows = append(ret.Rows, pdk.Row{Field: "allergies", ID: a})
+	}
+	return ret
+}
+
+func ingestPilosaRecord(indexer pdk.Indexer, pr pdk.PilosaRecord) {
+	for _, row := range pr.Rows {
+		indexer.AddColumn(row.Field, pr.Col, row.ID)
+	}
+	for _, val := range pr.Vals {
+		indexer.AddValue(val.Field, pr.Col, val.Value)
+	}
+
+}

--- a/usecase/fakeusers/cmd_test.go
+++ b/usecase/fakeusers/cmd_test.go
@@ -1,0 +1,60 @@
+package fakeusers_test
+
+import (
+	"testing"
+
+	gopilosa "github.com/pilosa/go-pilosa"
+	"github.com/pilosa/pilosa/test"
+
+	"github.com/pilosa/pdk/usecase/fakeusers"
+)
+
+func TestFakeUsers(t *testing.T) {
+	cluster := test.MustRunCluster(t, 3)
+	client, err := gopilosa.NewClient([]string{cluster[0].URL(), cluster[1].URL(), cluster[2].URL()})
+	if err != nil {
+		t.Fatalf("getting new client: %v", err)
+	}
+
+	main := fakeusers.NewMain()
+
+	main.Num = 1000
+	main.PilosaHosts = []string{cluster[0].URL(), cluster[1].URL(), cluster[2].URL()}
+
+	main.Run()
+
+	_, titleField := GetField(t, client, "users", "title")
+
+	resp := query(t, client, titleField.TopN(10))
+	items := resp.Result().CountItems()
+	if len(items[0].Key) < 1 {
+		t.Fatalf("should have a key: %#v", items[0])
+	}
+	if items[0].Count < items[1].Count || items[1].Count < 1 {
+		t.Fatalf("bad counts: %v", items)
+	}
+
+}
+
+func query(t *testing.T, c *gopilosa.Client, query gopilosa.PQLQuery) *gopilosa.QueryResponse {
+	resp, err := c.Query(query)
+	if err != nil {
+		t.Fatalf("querying: %v", err)
+	}
+	return resp
+}
+
+func GetField(t *testing.T, c *gopilosa.Client, index, field string) (*gopilosa.Index, *gopilosa.Field) {
+	schema, err := c.Schema()
+	if err != nil {
+		t.Fatalf("getting schema: %v", err)
+	}
+	idx := schema.Index(index)
+	fram := idx.Field(field)
+	err = c.SyncSchema(schema)
+	if err != nil {
+		t.Fatalf("syncing schema: %v", err)
+	}
+
+	return idx, fram
+}

--- a/usecase/taxi/Makefile
+++ b/usecase/taxi/Makefile
@@ -1,0 +1,11 @@
+PILOSA_IP=""
+
+install:
+	cd ../..; \
+	make install
+
+run: install
+	nohup pdk taxi -f ./greenAndYellowUrls.txt --pilosa $PILOSA_IP:10101 -b 1000000 -c 6 -e 2 &> taxi.out &
+
+logs:
+	tail -f taxi.out

--- a/usecase/taxi/main.go
+++ b/usecase/taxi/main.go
@@ -155,6 +155,8 @@ func (m *Main) Run() error {
 	pdk.NewRankedField(index, "pickup_elevation", 10000)
 	pdk.NewRankedField(index, "drop_elevation", 10000)
 
+	pdk.NewRankedField(index, "user_id", 100000)
+
 	m.indexer, err = pdk.SetupPilosa([]string{m.PilosaHost}, m.Index, schema, uint(m.BufferSize))
 	if err != nil {
 		return errors.Wrap(err, "setting up indexer")
@@ -197,7 +199,7 @@ func (m *Main) Run() error {
 	for i := 0; i < m.Concurrency; i++ {
 		wg2.Add(1)
 		go func() {
-			m.parseMapAndPost(records)
+			m.parseMapAndPost(records, i)
 			wg2.Done()
 		}()
 	}
@@ -363,7 +365,8 @@ type columnField struct {
 	Field  string
 }
 
-func (m *Main) parseMapAndPost(records <-chan record) {
+func (m *Main) parseMapAndPost(records <-chan record, num int) {
+	ug := newUserGetter(num)
 Records:
 	for record := range records {
 		fields, ok := record.clean()
@@ -386,7 +389,7 @@ Records:
 			continue
 		}
 		columnsToSet := make([]columnField, 0)
-		columnsToSet = append(columnsToSet, columnField{Column: cabType, Field: "cab_type"})
+		columnsToSet = append(columnsToSet, columnField{Column: cabType, Field: "cab_type"}, columnField{Column: ug.ID(), Field: "user_id"})
 		for _, bm := range bms {
 			if len(bm.Fields) != len(bm.Parsers) {
 				// TODO if len(pm.Parsers) == 1, use that for all fields
@@ -461,6 +464,7 @@ Records:
 				columnsToSet = append(columnsToSet, columnField{Column: uint64(id), Field: bm.Field})
 			}
 		}
+		columnsToSet = append(columnsToSet)
 		columnID := m.nexter.Next()
 		for _, bit := range columnsToSet {
 			m.indexer.AddColumn(bit.Field, columnID, bit.Column)

--- a/usecase/taxi/main_test.go
+++ b/usecase/taxi/main_test.go
@@ -33,6 +33,7 @@
 package taxi_test
 
 import (
+	"fmt"
 	"testing"
 
 	gopilosa "github.com/pilosa/go-pilosa"
@@ -100,6 +101,24 @@ func TestRunMain(t *testing.T) {
 		t.Fatalf("wrong second item for Topn(cab_type): %v", items)
 	}
 
+	_, userField := GetField(t, client, "taxi", "user_id")
+	resp, err = client.Query(index.Count(userField.Row(0)))
+	if err != nil {
+		t.Fatalf("count user 0 query: %v", err)
+	}
+	fmt.Println("user0: ", resp.Result().Count())
+
+	resp, err = client.Query(index.Count(userField.Row(1)))
+	if err != nil {
+		t.Fatalf("count user 1 query: %v", err)
+	}
+	fmt.Println("user1: ", resp.Result().Count())
+
+	resp, err = client.Query(userField.TopN(10))
+	if err != nil {
+		t.Fatalf("count user 1 query: %v", err)
+	}
+	fmt.Println("usertopn: ", resp.Result().CountItems())
 }
 
 func GetField(t *testing.T, c *gopilosa.Client, index, field string) (*gopilosa.Index, *gopilosa.Field) {

--- a/usecase/taxi/user.go
+++ b/usecase/taxi/user.go
@@ -1,0 +1,20 @@
+package taxi
+
+import (
+	"math/rand"
+)
+
+type userGetter struct {
+	z *rand.Zipf
+}
+
+func newUserGetter(seed int) *userGetter {
+	r := rand.New(rand.NewSource(int64(seed)))
+	return &userGetter{
+		z: rand.NewZipf(r, 1.1, 1024, 5000000), // zipfian distribution over 5 million users
+	}
+}
+
+func (u *userGetter) ID() uint64 {
+	return u.z.Uint64()
+}

--- a/usecase/taxi/user_test.go
+++ b/usecase/taxi/user_test.go
@@ -1,0 +1,25 @@
+package taxi
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestUserGetter(t *testing.T) {
+	ug := newUserGetter(0)
+	results := make(map[uint64]int)
+	for i := 0; i < 120000000; i++ {
+		results[ug.ID()]++
+	}
+
+	fmt.Println("Number of users generated", len(results))
+	last := uint64(0)
+	for i := uint64(0); i < 5000000; i += 100000 {
+		if results[i] > 0 {
+			last = i
+		}
+		fmt.Printf("%d: %d\n", i, results[i])
+	}
+	fmt.Println("last:", last, " results[last] ", results[last])
+
+}

--- a/usecase/userid/cmd.go
+++ b/usecase/userid/cmd.go
@@ -1,0 +1,67 @@
+package userid
+
+import (
+	"math/rand"
+	"time"
+
+	gopilosa "github.com/pilosa/go-pilosa"
+	"github.com/pilosa/pdk"
+	"github.com/pkg/errors"
+)
+
+// Main holds the options for generating fake data and ingesting it to Pilosa.
+type Main struct {
+	Seed        int64    `help:"Random seed for generating data. -1 will use current nanosecond."`
+	Num         uint64   `help:"Number of records to generate. 0 means infinity."`
+	PilosaHosts []string `help:"Comma separated list of Pilosa hosts and ports."`
+	Index       string   `help:"Pilosa index."`
+	BatchSize   uint     `help:"Batch size for Pilosa imports (latency/throughput tradeoff)."`
+}
+
+// NewMain returns a new Main.
+func NewMain() *Main {
+	return &Main{
+		Num:         1266087512,
+		PilosaHosts: []string{"localhost:10101"},
+		Index:       "taxi",
+		BatchSize:   100000,
+	}
+}
+
+// Run begins generating data and ingesting it to Pilosa.
+func (m *Main) Run() error {
+	if m.Seed == -1 {
+		m.Seed = time.Now().UnixNano()
+	}
+
+	schema := gopilosa.NewSchema()
+	idx := schema.Index(m.Index)
+	idx.Field("user_id2", gopilosa.OptFieldTypeSet(gopilosa.CacheTypeRanked, 50000))
+	indexer, err := pdk.SetupPilosa(m.PilosaHosts, m.Index, schema, m.BatchSize)
+	if err != nil {
+		return errors.Wrap(err, "setting up Pilosa")
+	}
+
+	ug := newUserGetter(m.Seed)
+
+	for i := uint64(0); i < m.Num; i++ {
+		indexer.AddColumn("user_id2", i, ug.ID())
+	}
+
+	return errors.Wrap(indexer.Close(), "closing indexer")
+}
+
+type userGetter struct {
+	z *rand.Zipf
+}
+
+func newUserGetter(seed int64) *userGetter {
+	r := rand.New(rand.NewSource(seed))
+	return &userGetter{
+		z: rand.NewZipf(r, 1.1, 1024, 5000000), // zipfian distribution over 5 million users
+	}
+}
+
+func (u *userGetter) ID() uint64 {
+	return u.z.Uint64()
+}


### PR DESCRIPTION
I pushed this accidentally to master and then reverted it which caused weird
merge conflicts when I actually wanted to create a pull request. Now I've
re-applied it as a single patch on top of master.

adds a command which generates fake users, adds a command which generates user ids (e.g. to associate with taxi rides) with a semi-realistic distribution.

adds some support to pdk indexer for string keys as rows or columns. This support is used by the fake users command.

This replaces #105 