### PR TITLE
allow mapper to send string row keys to pilosa

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -129,11 +129,15 @@ func (m *CollapsingMapper) mapLit(val Literal, pr *PilosaRecord, path []string) 
 		if field == "" {
 			return nil
 		}
-		id, err := m.Translator.GetID(field, tval)
-		if err != nil {
-			return errors.Wrapf(err, "getting id from %v", val)
+		if m.Translator != nil {
+			id, err := m.Translator.GetID(field, tval)
+			if err != nil {
+				return errors.Wrapf(err, "getting id from %v", val)
+			}
+			pr.AddRow(field, id)
+		} else {
+			pr.AddRow(field, string(tval))
 		}
-		pr.AddRow(field, id)
 	case B:
 		// for bools, use the last path element as the row name - only set if val is true
 		if !tval {
@@ -150,11 +154,15 @@ func (m *CollapsingMapper) mapLit(val Literal, pr *PilosaRecord, path []string) 
 			}
 		}
 		rowname := path[len(path)-1]
-		id, err := m.Translator.GetID(field, rowname)
-		if err != nil {
-			return errors.Wrapf(err, "getting bool id from %v", field)
+		if m.Translator != nil {
+			id, err := m.Translator.GetID(field, rowname)
+			if err != nil {
+				return errors.Wrapf(err, "getting bool id from %v", field)
+			}
+			pr.AddRow(field, id)
+		} else {
+			pr.AddRow(field, rowname)
 		}
-		pr.AddRow(field, id)
 	}
 	return nil
 }
@@ -206,8 +214,8 @@ func (pr *PilosaRecord) AddVal(field string, value int64) {
 }
 
 // AddRow adds a new column to be set to the PilosaRecord.
-func (pr *PilosaRecord) AddRow(field string, id uint64) {
-	pr.Rows = append(pr.Rows, Row{Field: field, ID: id})
+func (pr *PilosaRecord) AddRow(field string, idOrKey uint64OrString) {
+	pr.Rows = append(pr.Rows, Row{Field: field, ID: idOrKey})
 }
 
 // AddRowTime adds a new column to be set with a timestamp to the PilosaRecord.

--- a/mapper.go
+++ b/mapper.go
@@ -65,17 +65,17 @@ func NewCollapsingMapper() *CollapsingMapper {
 // Map implements the RecordMapper interface.
 func (m *CollapsingMapper) Map(e *Entity) (PilosaRecord, error) {
 	pr := PilosaRecord{}
-	var col uint64
-	var err error
 	if m.ColTranslator != nil {
-		col, err = m.ColTranslator.GetID(string(e.Subject))
+		col, err := m.ColTranslator.GetID(string(e.Subject))
 		if err != nil {
 			return pr, errors.Wrap(err, "getting column id from subject")
 		}
+		pr.Col = col
+	} else if m.Nexter != nil {
+		pr.Col = m.Nexter.Next()
 	} else {
-		col = m.Nexter.Next()
+		pr.Col = string(e.Subject)
 	}
-	pr.Col = col
 	return pr, m.mapObj(e, &pr, []string{})
 }
 

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -33,51 +33,120 @@
 package pdk_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/pilosa/pdk"
 )
 
 func TestCollapsingMapper(t *testing.T) {
-	cm := pdk.NewCollapsingMapper()
-	e := &pdk.Entity{
-		Subject: "blah",
-		Objects: map[pdk.Property]pdk.Object{
-			"aa":     pdk.S("hello"),
-			"bb":     pdk.I(49),
-			"active": pdk.B(true),
-			"alive":  pdk.B(true),
+	tests := []struct {
+		nilColTranslator bool
+		nilTranslator    bool
+		nilNexter        bool
+		expCol           interface{}
+		expRows          map[string]interface{}
+	}{
+		{
+			false,
+			false,
+			false,
+			uint64(0),
+			map[string]interface{}{"aa": uint64(0)},
+		},
+		{
+			true,
+			false,
+			false,
+			uint64(0),
+			map[string]interface{}{"aa": uint64(0)},
+		},
+		{
+			true,
+			false,
+			true,
+			"blah",
+			map[string]interface{}{"aa": uint64(0)},
+		},
+		{
+			true,
+			true,
+			true,
+			"blah",
+			map[string]interface{}{"aa": "hello"},
 		},
 	}
-	pr, err := cm.Map(e)
-	if err != nil {
-		t.Fatalf("mapping entity: %v", err)
-	}
-	val, err := cm.Translator.Get("aa", 0)
-	if err != nil {
-		t.Fatalf("translator get: %v", err)
-	}
-	if val != pdk.S("hello") {
-		t.Fatalf("bad val from translator")
-	}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("test-%d", i), func(t *testing.T) {
+			cm := pdk.NewCollapsingMapper()
+			if test.nilColTranslator {
+				cm.ColTranslator = nil
+			}
+			if test.nilTranslator {
+				cm.Translator = nil
+			}
+			if test.nilNexter {
+				cm.Nexter = nil
+			}
 
-	idactive, err := cm.Translator.GetID("default", "active")
-	if err != nil {
-		t.Fatal(err)
-	}
-	idalive, err := cm.Translator.GetID("default", "alive")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !(idalive == 0 && idactive == 1 || idactive == 0 && idalive == 1) {
-		t.Fatalf("mapping error, active: %v, alive: %v", idactive, idalive)
-	}
+			e := &pdk.Entity{
+				Subject: "blah",
+				Objects: map[pdk.Property]pdk.Object{
+					"aa":     pdk.S("hello"),
+					"bb":     pdk.I(49),
+					"active": pdk.B(true),
+					"alive":  pdk.B(true),
+				},
+			}
+			pr, err := cm.Map(e)
+			if err != nil {
+				t.Fatalf("mapping entity: %v", err)
+			}
 
-	if len(pr.Rows) != 3 {
-		t.Fatalf("wrong rows: %v", pr.Rows)
-	}
-	if len(pr.Vals) != 1 {
-		t.Fatalf("wrong vals: %v", pr.Vals)
-	}
+			if cm.Translator != nil {
+				val, err := cm.Translator.Get("aa", 0)
+				if err != nil {
+					t.Fatalf("translator get: %v", err)
+				}
+				if val != pdk.S("hello") {
+					t.Fatalf("bad val from translator")
+				}
 
+				idactive, err := cm.Translator.GetID("default", "active")
+				if err != nil {
+					t.Fatal(err)
+				}
+				idalive, err := cm.Translator.GetID("default", "alive")
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !(idalive == 0 && idactive == 1 || idactive == 0 && idalive == 1) {
+					t.Fatalf("mapping error, active: %v, alive: %v", idactive, idalive)
+				}
+			}
+
+			if len(pr.Rows) != 3 {
+				t.Fatalf("wrong rows: %v", pr.Rows)
+			}
+			if len(pr.Vals) != 1 {
+				t.Fatalf("wrong vals: %v", pr.Vals)
+			}
+
+			// Ensure the field values are correct.
+			for _, f := range pr.Rows {
+				// For now we only look at the aa field. The map in test.expRows makes it hard to test rows
+				// that get mapped to the same field, so that part of the test would need to be changed.
+				if f.Field == "aa" {
+					if f.ID != test.expRows[f.Field] {
+						t.Fatalf("wrong row id, expected: %v, but got: %v", test.expRows[f.Field], f.ID)
+					}
+				}
+			}
+
+			// Ensure the column value is correct.
+			if pr.Col != test.expCol {
+				t.Fatalf("wrong col, expected: %v, but got: %v", test.expCol, pr.Col)
+			}
+		})
+	}
 }

--- a/pipeline.go
+++ b/pipeline.go
@@ -62,7 +62,7 @@ type RecordMapper interface {
 // Indexer puts stuff into Pilosa.
 type Indexer interface {
 	AddColumn(field string, col, row uint64OrString)
-	AddColumnTimestamp(field string, col, row uint64, ts time.Time)
+	AddColumnTimestamp(field string, col, row uint64OrString, ts time.Time)
 	AddValue(field string, col uint64OrString, val int64)
 	// AddRowAttr(field string, row uint64, key string, value AttrVal)
 	// AddColAttr(col uint64, key string, value AttrVal)

--- a/proxy.go
+++ b/proxy.go
@@ -59,7 +59,7 @@ type Proxy interface {
 	ProxyRequest(orig *http.Request, origbody []byte) (*http.Response, error)
 }
 
-// StartMappingProxy listens for incoming http connections on `bind` and
+// StartMappingProxy listens for incoming http connections on `bind`
 // and uses h to handle all requests.
 // This function does not return unless there is a problem (like
 // http.ListenAndServe).

--- a/translator.go
+++ b/translator.go
@@ -99,7 +99,7 @@ func (m *MapTranslator) GetID(field string, val interface{}) (id uint64, err err
 	return m.getFieldTranslator(field).GetID(val)
 }
 
-// MapFieldTranslator is an in-memory implementation of FrameTranslator using
+// MapFieldTranslator is an in-memory implementation of FieldTranslator using
 // sync.Map and a slice.
 type MapFieldTranslator struct {
 	m sync.Map
@@ -110,7 +110,7 @@ type MapFieldTranslator struct {
 	s []interface{}
 }
 
-// NewMapFieldTranslator creates a new MapFrameTranslator.
+// NewMapFieldTranslator creates a new MapFieldTranslator.
 func NewMapFieldTranslator() *MapFieldTranslator {
 	return &MapFieldTranslator{
 		n: NewNexter(),
@@ -159,7 +159,7 @@ func (m *MapFieldTranslator) GetID(val interface{}) (id uint64, err error) {
 	return nextid, nil
 }
 
-// NexterFrameTranslator satisfies the FrameTranslator interface, but simply
+// NexterFrameTranslator satisfies the FieldTranslator interface, but simply
 // allocates a new contiguous id every time GetID(val) is called. It does not
 // store any mapping and Get(id) always returns an error. Pilosa requires column
 // ids regardless of whether we actually require tracking what each individual


### PR DESCRIPTION
This is incomplete, but I wanted to push this up and see if you have any concerns at this point.
I'm trying to leverage the PDK code as much as I can, but there are parts where it's pretty dependent on `uint64` keys, especially around translation. In the case where I want Pilosa to manage the translation (as opposed to an external `Translator` such as `MapTranslator`, I actually don't want `Translator.GetID` to be called at all.

(Also, there are a couple of places where I replaced `Frame` with `Field`. There are other instances that I did not change, but that's because they are currently part of the public API.
