### PR TITLE
add RawSource type and implementations

### DIFF
--- a/csv2/source.go
+++ b/csv2/source.go
@@ -1,0 +1,103 @@
+package csv2
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+
+	"github.com/pilosa/pdk"
+	"github.com/pkg/errors"
+)
+
+type Source struct {
+	rs pdk.RawSource
+
+	cur    pdk.NamedReadCloser
+	scan   *bufio.Scanner
+	header []string
+	line   int
+}
+
+func NewSourceFromRawSource(rs pdk.RawSource) *Source {
+	return &Source{
+		rs: rs,
+	}
+}
+
+func (s *Source) Record() (record interface{}, err error) {
+	if s.cur == nil {
+		s.cur, err = s.rs.NextReader()
+		if err != nil {
+			return nil, err
+		}
+		// scan header line
+		s.scan = bufio.NewScanner(s.cur)
+		if s.scan.Scan() && s.scan.Err() == nil {
+			s.header = strings.Split(s.scan.Text(), ",")
+			if err := validateHeader(s.header); err != nil {
+				s.cur = nil
+				s.scan = nil
+				s.line = 0
+				return nil, errors.Wrap(err, "validating header")
+			}
+		}
+	}
+	scan := s.scan
+	for scan.Scan() {
+		s.line++
+		if err := scan.Err(); err != nil {
+			return nil, err
+		}
+		txt := scan.Text()
+		if strings.TrimSpace(txt) == "" {
+			continue // skip empty lines. TODO: add stats tracking
+		}
+		row := strings.Split(txt, ",")
+		recordMap, err := parseRecord(s.header, row)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parsing")
+		}
+		// add file and line number under the comma header since that can't
+		// be a header from the csv file.
+		recordMap[","] = fmt.Sprintf("%s:line%d", s.cur.Name(), s.line)
+		return recordMap, nil
+	}
+	return nil, io.EOF
+
+}
+
+func validateHeader(header []string) error {
+	fields := make(map[string]int)
+	for i, h := range header {
+		if h == "" {
+			return errors.Errorf("header contains empty string at %d: %v", i, header)
+		}
+		if pos, exists := fields[h]; exists {
+			return errors.Errorf("%s appeared at both %d and %d in header", h, pos, i)
+		}
+		fields[h] = i
+	}
+	return nil
+}
+
+func parseRecord(header []string, row []string) (map[string]string, error) {
+	if len(header) > len(row) {
+		return nil, errors.Errorf("header/row len mismatch: %dvs%d, %v and %v", len(header), len(row), header, row)
+	} else if len(row) > len(header) {
+		for i := len(header); i < len(row); i++ {
+			if strings.TrimSpace(row[i]) != "" {
+				log.Printf("data in non headered field: %v, %d", row, i)
+			}
+		}
+	}
+	ret := make(map[string]string, len(header))
+	for i := 0; i < len(header); i++ {
+		if row[i] == "" {
+			continue
+		}
+		ret[header[i]] = row[i]
+	}
+	return ret, nil
+}

--- a/csv2/source.go
+++ b/csv2/source.go
@@ -2,7 +2,6 @@ package csv2
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"log"
 	"strings"
@@ -59,9 +58,6 @@ func (s *Source) Record() (record interface{}, err error) {
 		if err != nil {
 			return nil, errors.Wrapf(err, "parsing")
 		}
-		// add file and line number under the comma header since that can't
-		// be a header from the csv file.
-		recordMap[","] = fmt.Sprintf("%s:line%d", s.cur.Name(), s.line)
 		return recordMap, nil
 	}
 	return nil, io.EOF

--- a/csv2/source_test.go
+++ b/csv2/source_test.go
@@ -1,0 +1,61 @@
+package csv2
+
+import (
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/pilosa/pdk/file"
+)
+
+func mustTempDir(t *testing.T, prefix string) string {
+	t.Helper()
+	d, err := ioutil.TempDir("", prefix)
+	if err != nil {
+		t.Fatal("getting temp dir")
+	}
+	return d
+}
+
+func mustFile(t *testing.T, dir, contents string) (name string) {
+	t.Helper()
+	f, err := ioutil.TempFile(dir, "")
+	if err != nil {
+		t.Fatalf("getting temp file: %v", err)
+	}
+
+	_, err = io.WriteString(f, contents)
+	if err != nil {
+		t.Fatalf("writing contents: %v", err)
+	}
+
+	return f.Name()
+}
+
+func TestSource(t *testing.T) {
+	d := mustTempDir(t, "testcsvsource")
+
+	mustFile(t, d, `lah,hah,zlah
+1,2,sbldak
+4,8,kfue`)
+	mustFile(t, d, `lah,hah,zlah
+11,12,hi
+9,10,by`)
+
+	rs, err := file.NewRawSource(d)
+	if err != nil {
+		t.Fatalf("getting raw source: %v", err)
+	}
+
+	s := NewSourceFromRawSource(rs)
+
+	rec, err := s.Record()
+	for ; err != io.EOF; rec, err = s.Record() {
+		reci := rec.(map[string]string)
+		for _, key := range []string{"hah", "lah", "zlah"} {
+			if _, ok := reci[key]; !ok {
+				t.Fatalf("key %s not found", key)
+			}
+		}
+	}
+}

--- a/file/source.go
+++ b/file/source.go
@@ -53,6 +53,7 @@ func (s *Source) run() {
 		for i := 0; true; i++ {
 			r.data, r.err = src.Record()
 			if r.err == io.EOF {
+				reader.Close()
 				break
 			}
 			if s.subjectAt != "" {

--- a/file/source_test.go
+++ b/file/source_test.go
@@ -1,0 +1,127 @@
+package file
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/pilosa/pdk"
+)
+
+func mustTempDir(t *testing.T, prefix string) string {
+	t.Helper()
+	d, err := ioutil.TempDir("", prefix)
+	if err != nil {
+		t.Fatal("getting temp dir")
+	}
+	return d
+}
+
+func mustFile(t *testing.T, dir, contents string) (name string) {
+	t.Helper()
+	f, err := ioutil.TempFile(dir, "")
+	if err != nil {
+		t.Fatalf("getting temp file: %v", err)
+	}
+
+	_, err = io.WriteString(f, contents)
+	if err != nil {
+		t.Fatalf("writing contents: %v", err)
+	}
+
+	return f.Name()
+}
+
+func TestRawSource(t *testing.T) {
+	d := mustTempDir(t, "testrawsource")
+	defer func() {
+		os.RemoveAll(d)
+	}()
+
+	names := make([]string, 0, 2)
+	names = append(names, filepath.Base(mustFile(t, d, `blah blah blah`)))
+	names = append(names, filepath.Base(mustFile(t, d, `hahahahahahahaha`)))
+
+	rs, err := NewRawSource(d)
+	if err != nil {
+		t.Fatalf("getting raw source: %v", err)
+	}
+
+	gotNames := make([]string, 0, 2)
+	var reader pdk.NamedReadCloser
+	for reader, err = rs.NextReader(); err == nil; reader, err = rs.NextReader() {
+		gotNames = append(gotNames, reader.Name())
+		buf, err := ioutil.ReadAll(reader)
+		if err != nil {
+			t.Fatalf("reading file: %v", err)
+		}
+		t.Logf("%s\n", buf)
+	}
+	if !reflect.DeepEqual(gotNames, names) {
+		names[0], names[1] = names[1], names[0]
+		if !reflect.DeepEqual(gotNames, names) {
+			t.Fatalf("different file names: %v", gotNames)
+		}
+	}
+	if err != io.EOF {
+		t.Fatalf("unexpected NextReader error: %v", err)
+	}
+
+}
+
+func TestSource(t *testing.T) {
+	d := mustTempDir(t, "testsource")
+	defer func() {
+		os.RemoveAll(d)
+	}()
+
+	mustFile(t, d, `
+{"hey": 44}
+{"hey": 39}
+`)
+
+	mustFile(t, d, `
+{"hey": 81}
+{"hey": 22}
+`)
+
+	s, err := NewSource(OptSrcSubjectAt("here"), OptSrcPath(d))
+	if err != nil {
+		t.Fatalf("getting source: %v", err)
+	}
+
+	vals := make(map[int]struct{})
+
+	var rec interface{}
+	for rec, err = s.Record(); err == nil; rec, err = s.Record() {
+		recm, ok := rec.(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected map[string]interface{} but got %T", rec)
+		}
+
+		v, ok := recm["hey"]
+		if !ok {
+			t.Fatalf("key 'hey' not present in %v", recm)
+		}
+
+		if vi, ok := v.(float64); ok {
+			vals[int(vi)] = struct{}{}
+		} else {
+			t.Fatalf("expected float")
+		}
+	}
+
+	if len(vals) != 4 {
+		t.Fatalf("wrong num of vals: %v", vals)
+	}
+
+	for _, v := range []int{44, 39, 81, 22} {
+		if _, ok := vals[v]; !ok {
+			t.Fatalf("didn't find %d in %v", v, vals)
+		}
+	}
+
+}


### PR DESCRIPTION
This will allow us to easily separate the logic for connecting to a
particular data source, with the type of data contained. This makes
sense for generic data sources like local files or S3 where the type
of data can be anything (e.g. CSV, JSON, XML...)

@codysoyland FYI. Changes to pipeline.go summarize my thinking. LMK if you have any feedback on this direction.

Still have more to do (e.g. local file RawSource, CSVSourceFromRawSource).